### PR TITLE
xacro.py changed to xacro

### DIFF
--- a/rotors_gazebo/launch/spawn_mav.launch
+++ b/rotors_gazebo/launch/spawn_mav.launch
@@ -16,7 +16,7 @@
 
   <!-- send the robot XML to param server -->
   <param name="robot_description" command="
-    $(find xacro)/xacro.py '$(arg model)'
+    $(find xacro)/xacro '$(arg model)'
     enable_logging:=$(arg enable_logging)
     enable_ground_truth:=$(arg enable_ground_truth)
     enable_mavlink_interface:=$(arg enable_mavlink_interface)


### PR DESCRIPTION
The previously deprecated xacro.py executable has been removed in ROS noetic ([https://wiki.ros.org/noetic/Migration#Use_xacro_instead_of_xacro.py](https://wiki.ros.org/noetic/Migration#Use_xacro_instead_of_xacro.py)). Therefore, running this launch file in ROS noetic results in an error.